### PR TITLE
Album for gallery made & Hovering issue fixed in what we do section .

### DIFF
--- a/aavesh/src/components/Gallery.jsx
+++ b/aavesh/src/components/Gallery.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
-import { GALLERY_ITEMS } from '../constants/gallery';
+import { useState } from 'react';
+import { GALLERY_ALBUMS } from '../constants/gallery';
 const DecoratorCircleFirst = ({ className }) => (
   <svg width="70" height="12" viewBox="0 0 70 12" fill="none" xmlns="http://www.w3.org/2000/svg" className={className}>
     <circle cx="4" cy="6" r="3.5" fill="currentColor"/>
@@ -20,6 +21,59 @@ DecoratorLinesFirst.propTypes = {
 };
 // galleryItems now imported from constants
 const Gallery = () => {
+  const [selectedAlbum, setSelectedAlbum] = useState(null);
+  const [selectedImageIndex, setSelectedImageIndex] = useState(0);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const openAlbum = (album) => {
+    setSelectedAlbum(album);
+    setSelectedImageIndex(0);
+  };
+
+  const closeAlbum = () => {
+    setSelectedAlbum(null);
+    setIsModalOpen(false);
+  };
+
+  const openImageModal = (index) => {
+    setSelectedImageIndex(index);
+    setIsModalOpen(true);
+  };
+
+  const closeImageModal = () => {
+    setIsModalOpen(false);
+  };
+
+  const nextImage = () => {
+    if (selectedAlbum) {
+      setSelectedImageIndex((prev) => 
+        prev === selectedAlbum.images.length - 1 ? 0 : prev + 1
+      );
+    }
+  };
+
+  const prevImage = () => {
+    if (selectedAlbum) {
+      setSelectedImageIndex((prev) => 
+        prev === 0 ? selectedAlbum.images.length - 1 : prev - 1
+      );
+    }
+  };
+
+  const handleKeyPress = (e) => {
+    if (isModalOpen) {
+      if (e.key === 'ArrowRight') nextImage();
+      if (e.key === 'ArrowLeft') prevImage();
+      if (e.key === 'Escape') closeImageModal();
+    }
+  };
+
+  // Add event listener for keyboard navigation
+  useState(() => {
+    document.addEventListener('keydown', handleKeyPress);
+    return () => document.removeEventListener('keydown', handleKeyPress);
+  }, [isModalOpen]);
+
   return (
     <>
       <style>
@@ -31,49 +85,149 @@ const Gallery = () => {
         `}
       </style>
       <div className="flex flex-col items-center min-h-screen bg-black text-white p-4 md:p-8 font-iceland">
-        <header className="w-full max-w-5xl mb-20">
-          <div className="inline-flex flex-col">
-            <div className="self-start">
-              <DecoratorCircleFirst className="text-gray-400" />
+        <header className="w-full max-w-6xl mb-20">
+          <div className="flex items-center justify-between">
+            <div className="inline-flex flex-col">
+              <div className="self-start">
+                <DecoratorCircleFirst className="text-gray-400" />
+              </div>
+              <div className="self-center">
+                <h1 className="text-4xl font-light tracking-[0.3em] uppercase text-gray-200 py-2">
+                  {selectedAlbum ? selectedAlbum.title : 'Gallery'}
+                </h1>
+              </div>
+              <div className="self-end">
+                <DecoratorLinesFirst className="text-gray-400" />
+              </div>
             </div>
-            <div className="self-center">
-              <h1 className="text-4xl font-light tracking-[0.3em] uppercase text-gray-200 py-2">
-                Gallery
-              </h1>
-            </div>
-            <div className="self-end">
-              <DecoratorLinesFirst className="text-gray-400" />
-            </div>
+            {selectedAlbum && (
+              <button
+                onClick={closeAlbum}
+                className="text-gray-400 hover:text-white transition-colors text-2xl font-light"
+              >
+                ← Back to Albums
+              </button>
+            )}
           </div>
         </header>
-        <main className="w-full max-w-5xl">
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
-            {GALLERY_ITEMS.map(item => (
-              <div key={item.id} className="aspect-video rounded-md overflow-hidden cursor-pointer group">
-                {item.type === 'image' ? (
-                  <div className="relative w-full h-full">
+
+        <main className="w-full max-w-6xl">
+          {!selectedAlbum ? (
+            // Album Grid View
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-12">
+              {GALLERY_ALBUMS.map(album => (
+                <div 
+                  key={album.id} 
+                  className="group cursor-pointer"
+                  onClick={() => openAlbum(album)}
+                >
+                  <div className="relative aspect-[3/2] rounded-xl overflow-hidden mb-6">
                     <img 
-                      src={item.src} 
-                      alt={`Gallery item ${item.id}`} 
-                      className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
-                      onError={(e) => { e.target.onerror = null; e.target.src='https://placehold.co/600x400/000000/FFFFFF?text=Image'; }}
+                      src={album.coverImage} 
+                      alt={album.title}
+                      className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-110"
+                      onError={(e) => { 
+                        e.target.onerror = null; 
+                        e.target.src='https://placehold.co/600x400/000000/FFFFFF?text=Album'; 
+                      }}
                     />
+                    <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
+                    <div className="absolute bottom-6 left-6 right-6 transform translate-y-4 group-hover:translate-y-0 transition-transform duration-300">
+                      <span className="inline-block bg-teal-500 text-black px-4 py-2 rounded-full text-base font-medium">
+                        {album.images.length} photos
+                      </span>
+                    </div>
                   </div>
-                ) : (
-                  <div 
-                    className="relative w-full h-full bg-cover bg-center flex items-center justify-center transition-transform duration-300 group-hover:scale-105"
-                    style={{ backgroundImage: `url(${item.backgroundImage})` }}
-                  >
-                    <div className="absolute inset-0 bg-black/50"></div>
-                    <h2 className="relative z-10 text-3xl text-gray-200 tracking-widest">
-                      {item.title}
-                    </h2>
-                  </div>
-                )}
+                  <h3 className="text-3xl font-medium text-gray-200 group-hover:text-teal-400 transition-colors">
+                    {album.title}
+                  </h3>
+                  <p className="text-gray-400 text-lg mt-2">{album.description}</p>
+                </div>
+              ))}
+            </div>
+          ) : (
+            // Album Image Grid View
+            <div>
+              <div className="mb-8">
+                <p className="text-gray-400 text-lg">{selectedAlbum.description}</p>
+                <p className="text-gray-500 text-sm mt-2">{selectedAlbum.images.length} photos</p>
               </div>
-            ))}
-          </div>
+              <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+                {selectedAlbum.images.map((image, index) => (
+                  <div 
+                    key={image.id}
+                    className="group cursor-pointer"
+                    onClick={() => openImageModal(index)}
+                  >
+                    <div className="relative aspect-square rounded-lg overflow-hidden">
+                      <img 
+                        src={image.src} 
+                        alt={image.caption}
+                        className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
+                        onError={(e) => { 
+                          e.target.onerror = null; 
+                          e.target.src='https://placehold.co/300x300/000000/FFFFFF?text=Image'; 
+                        }}
+                      />
+                      <div className="absolute inset-0 bg-black/0 group-hover:bg-black/20 transition-colors duration-300"></div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
         </main>
+
+        {/* Image Modal */}
+        {isModalOpen && selectedAlbum && (
+          <div 
+            className="fixed inset-0 bg-black/95 z-50 flex items-center justify-center p-4"
+            onClick={closeImageModal}
+          >
+            <div className="relative max-w-4xl max-h-full">
+              <button
+                onClick={closeImageModal}
+                className="absolute top-4 right-4 text-white hover:text-gray-300 z-10 text-2xl font-light"
+              >
+                ✕
+              </button>
+              
+              <div className="relative" onClick={(e) => e.stopPropagation()}>
+                <img 
+                  src={selectedAlbum.images[selectedImageIndex].src}
+                  alt={selectedAlbum.images[selectedImageIndex].caption}
+                  className="max-w-full max-h-[80vh] object-contain"
+                />
+                
+                {selectedAlbum.images.length > 1 && (
+                  <>
+                    <button
+                      onClick={prevImage}
+                      className="absolute left-4 top-1/2 transform -translate-y-1/2 text-white hover:text-gray-300 text-3xl font-light bg-black/50 rounded-full w-12 h-12 flex items-center justify-center"
+                    >
+                      ‹
+                    </button>
+                    <button
+                      onClick={nextImage}
+                      className="absolute right-4 top-1/2 transform -translate-y-1/2 text-white hover:text-gray-300 text-3xl font-light bg-black/50 rounded-full w-12 h-12 flex items-center justify-center"
+                    >
+                      ›
+                    </button>
+                  </>
+                )}
+                
+                <div className="absolute bottom-4 left-1/2 transform -translate-x-1/2 text-center">
+                  <p className="text-white text-lg font-medium mb-2">
+                    {selectedAlbum.images[selectedImageIndex].caption}
+                  </p>
+                  <p className="text-gray-300 text-sm">
+                    {selectedImageIndex + 1} of {selectedAlbum.images.length}
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
       </div>
     </>
   );

--- a/aavesh/src/components/Sponsors.jsx
+++ b/aavesh/src/components/Sponsors.jsx
@@ -48,7 +48,7 @@ const Sponsors = () => {
               <DecoratorCircleFirst className="text-gray-400" />
             </div>
             <div className="py-2 self-start">
-              <h1 className="text-2xl sm:text-4xl font-normal tracking-[0.3em] uppercase text-gray-200">
+              <h1 className="text-2xl sm:text-4xl font-normal tracking-[0.1em] uppercase text-gray-200">
                 Sponsors
               </h1>
             </div>

--- a/aavesh/src/components/WhatWeDo.jsx
+++ b/aavesh/src/components/WhatWeDo.jsx
@@ -1,7 +1,7 @@
 import { marqueeDataTop, marqueeDataBottom } from '../constants/whatWeDo'; // Import static data from constants
 
 
-import { useState, useRef } from 'react';
+import { useState } from 'react';
 
 
 const marqueeStyles = `
@@ -19,7 +19,7 @@ const marqueeStyles = `
   .animate-marquee-right {
     animation: marquee-right 40s linear infinite;
   }
-  /* Pause animation on hover, but only if not paused by a click */
+  /* Pause animation on hover, but only if not paused by a hover */
   .marquee-container:not(.paused):hover .animate-marquee-left,
   .marquee-container:not(.paused):hover .animate-marquee-right {
     animation-play-state: paused;
@@ -27,58 +27,17 @@ const marqueeStyles = `
 `;
 
 
-const CloseIcon = (props) => (
-  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" {...props}>
-    <line x1="18" y1="6" x2="6" y2="18"></line>
-    <line x1="6" y1="6" x2="18" y2="18"></line>
-  </svg>
-);
-
-
 const WhatWeDo = () => {
-  const [selectedItem, setSelectedItem] = useState(null);
+  const [hoveredItem, setHoveredItem] = useState(null);
   const [isPaused, setIsPaused] = useState(false);
-  const [topOffset, setTopOffset] = useState(0);
-  const [bottomOffset, setBottomOffset] = useState(0);
 
-  const topMarqueeRef = useRef(null);
-  const bottomMarqueeRef = useRef(null);
-
-  const handleItemClick = (item, event, marqueeLine) => {
-    const topEl = topMarqueeRef.current;
-    const bottomEl = bottomMarqueeRef.current;
-    if (!topEl || !bottomEl) return;
-
-
-    const topStyle = window.getComputedStyle(topEl);
-    const topMatrix = new DOMMatrixReadOnly(topStyle.transform);
-    const currentTopX = topMatrix.m41;
-
-    const bottomStyle = window.getComputedStyle(bottomEl);
-    const bottomMatrix = new DOMMatrixReadOnly(bottomStyle.transform);
-    const currentBottomX = bottomMatrix.m41;
-    
-
-    const screenCenter = window.innerWidth / 2;
-    const itemRect = event.currentTarget.getBoundingClientRect();
-    const itemCenter = itemRect.left + itemRect.width / 2;
-    const centeringOffset = screenCenter - itemCenter;
-
-
-    if (marqueeLine === 'top') {
-      setTopOffset(currentTopX + centeringOffset);
-      setBottomOffset(currentBottomX);
-    } else {
-      setTopOffset(currentTopX);
-      setBottomOffset(currentBottomX + centeringOffset);
-    }
-
-    setSelectedItem(item);
+  const handleItemHover = (item) => {
+    setHoveredItem(item);
     setIsPaused(true);
   };
 
-  const handleCloseImage = () => {
-    setSelectedItem(null);
+  const handleItemLeave = () => {
+    setHoveredItem(null);
     setIsPaused(false);
   };
 
@@ -99,15 +58,13 @@ const WhatWeDo = () => {
           {/* Top Row */}
           <div className="overflow-hidden">
             <div 
-              ref={topMarqueeRef}
               className={`flex ${!isPaused ? 'animate-marquee-left' : ''}`}
-              style={{ 
-                transform: isPaused ? `translateX(${topOffset}px)` : 'none',
-                transition: 'transform 0.8s cubic-bezier(0.25, 1, 0.5, 1)'
-              }}
             >
               {topContent.map((item, index) => (
-                <div key={`top-${index}`} onClick={(e) => handleItemClick(item, e, 'top')} className="flex-shrink-0 mx-8 text-4xl md:text-6xl font-bold tracking-[0.2em] uppercase whitespace-nowrap cursor-pointer hover:text-teal-400 transition-colors duration-300">
+                <div key={`top-${index}`} 
+                     onMouseEnter={() => handleItemHover(item)} 
+                     onMouseLeave={handleItemLeave}
+                     className="flex-shrink-0 mx-8 text-4xl md:text-6xl font-bold tracking-[0.2em] uppercase whitespace-nowrap cursor-pointer hover:text-teal-400 transition-colors duration-300">
                   {item.text} <span className="text-teal-500 font-sans mx-4">&gt;</span>
                 </div>
               ))}
@@ -116,15 +73,13 @@ const WhatWeDo = () => {
 
           <div className="overflow-hidden">
             <div 
-              ref={bottomMarqueeRef}
               className={`flex ${!isPaused ? 'animate-marquee-right' : ''}`}
-              style={{ 
-                transform: isPaused ? `translateX(${bottomOffset}px)` : 'none',
-                transition: 'transform 0.8s cubic-bezier(0.25, 1, 0.5, 1)'
-              }}
             >
               {bottomContent.map((item, index) => (
-                <div key={`bottom-${index}`} onClick={(e) => handleItemClick(item, e, 'bottom')} className="flex-shrink-0 mx-8 text-4xl md:text-6xl font-bold tracking-[0.2em] uppercase whitespace-nowrap cursor-pointer hover:text-teal-400 transition-colors duration-300">
+                <div key={`bottom-${index}`} 
+                     onMouseEnter={() => handleItemHover(item)} 
+                     onMouseLeave={handleItemLeave}
+                     className="flex-shrink-0 mx-8 text-4xl md:text-6xl font-bold tracking-[0.2em] uppercase whitespace-nowrap cursor-pointer hover:text-teal-400 transition-colors duration-300">
                   {item.text} <span className="text-teal-500 font-sans mx-4">&gt;</span>
                 </div>
               ))}
@@ -133,14 +88,11 @@ const WhatWeDo = () => {
         </div>
 
 
-        {selectedItem && (
+        {hoveredItem && (
           <div className="absolute z-10 p-2 bg-white rounded-md shadow-2xl shadow-black/50 -rotate-6 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
-            <button onClick={handleCloseImage} className="absolute -top-3 -right-3 bg-black text-white rounded-full p-1.5 z-20 hover:bg-gray-700 transition-colors">
-              <CloseIcon />
-            </button>
             <img
-              src={selectedItem.image}
-              alt={selectedItem.text}
+              src={hoveredItem.image}
+              alt={hoveredItem.text}
               className="w-96 h-auto rounded"
               onError={(e) => { e.target.onerror = null; e.target.src='https://placehold.co/200x150/000000/FFFFFF?text=Image'; }}
             />

--- a/aavesh/src/components/WhatWeDo.jsx
+++ b/aavesh/src/components/WhatWeDo.jsx
@@ -89,7 +89,11 @@ const WhatWeDo = () => {
 
 
         {hoveredItem && (
-          <div className="absolute z-10 p-2 bg-white rounded-md shadow-2xl shadow-black/50 -rotate-6 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
+          <div 
+            className="absolute z-10 p-2 bg-white rounded-md shadow-2xl shadow-black/50 -rotate-6 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"
+            onMouseEnter={() => handleItemHover(hoveredItem)}
+            onMouseLeave={handleItemLeave}
+          >
             <img
               src={hoveredItem.image}
               alt={hoveredItem.text}

--- a/aavesh/src/constants/gallery.js
+++ b/aavesh/src/constants/gallery.js
@@ -1,3 +1,81 @@
+export const GALLERY_ALBUMS = [
+  {
+    id: 'events-2025',
+    title: 'Events 2025',
+    description: 'Highlights from our events this year',
+    coverImage: 'https://images.pexels.com/photos/2117937/pexels-photo-2117937.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1',
+    images: [
+      {
+        id: 1,
+        src: 'https://images.pexels.com/photos/325185/pexels-photo-325185.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1',
+        caption: 'Tech Event 2025'
+      },
+      {
+        id: 2,
+        src: 'https://images.pexels.com/photos/1181671/pexels-photo-1181671.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1',
+        caption: 'Innovation Workshop'
+      },
+      {
+        id: 3,
+        src: 'https://images.pexels.com/photos/1181359/pexels-photo-1181359.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1',
+        caption: 'Team Building Session'
+      },
+      {
+        id: 4,
+        src: 'https://images.pexels.com/photos/1181677/pexels-photo-1181677.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1',
+        caption: 'Networking Event'
+      }
+    ]
+  },
+  {
+    id: 'workshops',
+    title: 'Workshops',
+    description: 'Educational workshops and seminars',
+    coverImage: 'https://images.pexels.com/photos/1181359/pexels-photo-1181359.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1',
+    images: [
+      {
+        id: 5,
+        src: 'https://images.pexels.com/photos/3184465/pexels-photo-3184465.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1',
+        caption: 'AI/ML Workshop'
+      },
+      {
+        id: 6,
+        src: 'https://images.pexels.com/photos/3184396/pexels-photo-3184396.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1',
+        caption: 'Robotics Session'
+      },
+      {
+        id: 7,
+        src: 'https://images.pexels.com/photos/3184287/pexels-photo-3184287.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1',
+        caption: 'Programming Bootcamp'
+      }
+    ]
+  },
+  {
+    id: 'meraki-2025',
+    title: 'Meraki - 2025',
+    description: 'Our flagship event',
+    coverImage: 'https://images.pexels.com/photos/2117937/pexels-photo-2117937.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1',
+    images: [
+      {
+        id: 8,
+        src: 'https://images.pexels.com/photos/2608517/pexels-photo-2608517.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1',
+        caption: 'Meraki Opening Ceremony'
+      },
+      {
+        id: 9,
+        src: 'https://images.pexels.com/photos/2608514/pexels-photo-2608514.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1',
+        caption: 'Competition Finals'
+      },
+      {
+        id: 10,
+        src: 'https://images.pexels.com/photos/2608513/pexels-photo-2608513.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1',
+        caption: 'Awards Ceremony'
+      }
+    ]
+  }
+];
+
+// Keep the original for backward compatibility
 export const GALLERY_ITEMS = [
   {
     id: 1,


### PR DESCRIPTION
This pull request introduces significant enhancements to the `Gallery` component by implementing an album-based structure with modal functionality for viewing images, while also simplifying and improving the behavior of the `WhatWeDo` component. Minor adjustments were made to other components for consistency.

### Enhancements to the Gallery Component:
* Replaced the single `GALLERY_ITEMS` array with a new `GALLERY_ALBUMS` structure, enabling an album-based gallery view. Each album includes metadata and a collection of images. (`aavesh/src/constants/gallery.js`)
* Added state management (`useState`) to handle selected albums, image modals, and navigation within albums. New methods include `openAlbum`, `closeAlbum`, `openImageModal`, `closeImageModal`, `nextImage`, and `prevImage`. (`aavesh/src/components/Gallery.jsx`) [[1]](diffhunk://#diff-3d4e6ea58bed5214e044cc21243658a9209d19fac72652925d938feacf03b006L2-R3) [[2]](diffhunk://#diff-3d4e6ea58bed5214e044cc21243658a9209d19fac72652925d938feacf03b006R24-R76)
* Updated the gallery layout to display albums in a grid view and allow navigation to individual album images. Added keyboard navigation for modal interactions. (`aavesh/src/components/Gallery.jsx`)

### Simplifications to the WhatWeDo Component:
* Replaced the click-to-center functionality with hover-based behavior for better user experience. Removed complex state tracking for offsets and DOM manipulation. (`aavesh/src/components/WhatWeDo.jsx`) [[1]](diffhunk://#diff-6ed2f5aa0c70310c448a12003a0edf14f5de4bf1cff003bd521ca411a21a8287L22-R40) [[2]](diffhunk://#diff-6ed2f5aa0c70310c448a12003a0edf14f5de4bf1cff003bd521ca411a21a8287L102-R67) [[3]](diffhunk://#diff-6ed2f5aa0c70310c448a12003a0edf14f5de4bf1cff003bd521ca411a21a8287L119-R82)
* Simplified the marquee animations by removing unnecessary refs and state variables while retaining hover-based pause functionality. (`aavesh/src/components/WhatWeDo.jsx`) [[1]](diffhunk://#diff-6ed2f5aa0c70310c448a12003a0edf14f5de4bf1cff003bd521ca411a21a8287L4-R4) [[2]](diffhunk://#diff-6ed2f5aa0c70310c448a12003a0edf14f5de4bf1cff003bd521ca411a21a8287L136-R99)

### Minor Adjustments:
* Adjusted the header tracking in the `Sponsors` component for better visual alignment. (`aavesh/src/components/Sponsors.jsx`)
* Corrected a comment typo in the `WhatWeDo` component for clarity. (`aavesh/src/components/WhatWeDo.jsx`)